### PR TITLE
08/28/2025 bug fixes and enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Automated pipeline for functional CRISPR screen analyses
 
+## Table of Contents
+
+- [Workflow Overview](#workflow-overview)
+- [Installation](#installation)
+- [Pipeline Specifics](#pipeline-specifics)
+  - [Inputs](#inputs)
+  - [Outputs](#outputs)
+- [Contact Information](#contact-information)
+
 ## Workflow Overview
 
 ![](workflow/report/plots/workflow_flowchart.png)
@@ -48,17 +57,19 @@ When the command finishes, a directory titled `functional_CRISPR_screen` should 
 #!/bin/bash 
 
 functional_CRISPR_screen.py \
-    --cores 10 \ ## default
+    --cores 1 \ ## default
     --raw_seq_dir 'directory_with_raw_seqs' \ ## assumes that your raw sequence files end in .fastq.gz
     --metadata_file 'path/to/metadata.csv' \ ## see info on metadata formatting under inputs!
+    --out_dir_name 'crispr_screen_out' \ ## default - change to your project name if desired
     --bowtie_mismatches 0 \ ## default
     --vector_seq_used 'TTGTGGAAAGGACGAAACACCG' \ ## example sequence!
     --vector_seq_minOverlap 10 \ ## default
     --vector_seq_error 0.2 \ ## default
     --crispr_sgRNA_index "path/to/sgRNA_index.fasta" \
     --crispr_sgRNA_index_name "name_of_sgRNA_index" \
-    --use_singularity True \ ## only include this line if you want to run the pipeline in singularity/docker containers
-    --dry_run True ## only include this line if you want to dry run the pipeline 
+    --latency_wait 60 \ ## default - change if you have a slow (or faster) file system
+    --use_singularity \ ## only include this line if you want to run the pipeline in singularity/docker containers
+    --dry_run ## only include this line if you want to dry run the pipeline 
 ```
 
 This script just includes the command line parameters for the pipeline and allows you to easily add file paths to your input sequences, the sgRNA index `.fasta` file, and your metadata file. The input parameters also include the ability to run the pipeline in associated singularity/docker containers instead of conda environments and to dry run the pipeline once you put in all parameters to make sure that provided files are located where you said they were.
@@ -144,42 +155,48 @@ Pipeline inputs and definitions are as follows:
 > | transE-Medium_S46_L005_R1_001 | high             |
 > | transE-Pre_S48_L005_R1_001    | low              |
 
-4\. **--bowtie_mismatches:** This is set to 0 as a default but can be changed if the user wishes to
+4\. **--out_dir_name:** Provides option to change the name of the output directory, set to `crispr_screen_out` as a default but can be changed
 
-5\. **--vector_seq_used:** The sgRNA vector sequence used in the wet lab experiments
+5\. **--bowtie_mismatches:** This is set to 0 as a default but can be changed if the user wishes to
 
-6\. **--vector_seq_minOverlap:** This is set to a default of 10 but can be changed
+6\. **--vector_seq_used:** The sgRNA vector sequence used in the wet lab experiments
 
-7\. **--vector_seq_error:** This is set to a default of 0.2 but can be changed
+7\. **--vector_seq_minOverlap:** This is set to a default of 10 but can be changed
 
-8\. **--crispr_sgRNA_index:** The path to the sgRNA index `.fasta` file
+8\. **--vector_seq_error:** This is set to a default of 0.2 but can be changed
 
-9\. **--crispr_sgRNA_index_name:** The name of the sgRNA index that was used (where you got the associated `.fasta` file from)
+9\. **--crispr_sgRNA_index:** The path to the sgRNA index `.fasta` file
 
-10\. **--use_singularity:** Optional parameter to run the pipeline in singularity/docker containers instead of conda environments (default)
+10\. **--crispr_sgRNA_index_name:** The name of the sgRNA index that was used (where you got the associated `.fasta` file from)
+
+11\. **--latency_wait:** This is set to 60 (seconds) as a default but can be changed if the user wishes to
+
+12\. **--use_singularity:** Optional parameter to run the pipeline in singularity/docker containers instead of conda environments (default)
 
 > [!IMPORTANT] 
 > Apptainer **must** be installed to run this pipeline with singularity!
 
-11\. **--dry_run:** Optional parameter to dry run the pipeline to ensure that all file paths/parameters are referenced appropriately
+13\. **--dry_run:** Optional parameter to dry run the pipeline to ensure that all file paths/parameters are referenced appropriately
 
 | Parameter                 | Expected Type          | Input Required, Default, or Optional | Description                                                                                                      |
 |------------------|------------------|------------------|------------------|
-| --cores                   | numeric                | default = 10                         | The number of cores you want dedicated to the analysis, default of 10                                            |
+| --cores                   | numeric                | default = 1                         | The number of cores you want dedicated to the analysis, default of 10                                            |
 | --raw_seq_dir             | string of file path    | required                             | The path to the directory containing the raw sequence `.fastq.gz` files                                          |
 | --metadata_file           | string of file path    | required                             | The path to the metadata file as a `.csv`                                                                        |
+| --out_dir_name           | string    | default = "crispr_screen_out"                             | Provides option to change the name of the output directory                                                                        |
 | --bowtie_mismatches       | numeric                | default = 0                          | This is set to a default of 0 but can be changed                                                                 |
 | --vector_seq_used         | string of the sequence | required                             | The sgRNA vector sequence used in the wet lab experiments                                                        |
 | --vector_seq_minOverlap   | numeric                | default = 10                         | This is set to a default of 10 but can be changed                                                                |
 | --vector_seq_error        | numeric                | default = 0.2                        | This is set to a default of 0.2 but can be changed                                                               |
 | --crispr_sgRNA_index      | string of file path    | required                             | The path to the sgRNA index `.fasta` file                                                                        |
 | --crispr_sgRNA_index_name | string                 | required                             | The name of the sgRNA index that was used (where you got the associated `.fasta` file from)                      |
+| --latency_wait         | numeric            | default = 60                            | The amount of time (in seconds) to wait for files to be generated  |
 | --use_singularity         | True (bool)            | optional                             | Optional parameter to run the pipeline in singularity/docker containers instead of conda environments (default)  |
 | --dry_run                 | True (bool)            | optional                             | Optional parameter to dry run the pipeline to ensure that all file paths/parameters are referenced appropriately |
 
 ### Outputs:
 
-Pipeline outputs are contained in a directory named `crispr_screen_out` which should exist in your working directory upon completion of the pipeline. The directory will be structured like so:
+Pipeline outputs are contained in a directory named `crispr_screen_out`/`you_our_dir_name.crispr_screen_out` (depending on user input) which should exist in your working directory upon completion of the pipeline. The directory will be structured like so:
 
 ``` bash
 crispr_screen_out/
@@ -209,14 +226,14 @@ crispr_screen_out/
 │   ├── sample1_untrimmed.fastq.gz
 │   ├── sample2_trimmed.fastq.gz
 │   └── sample2_untrimmed.fastq.gz
-├── dev_report.html
+├── report.html
 ├── fastqc_outputs
 │   ├── sample1_fastqc.html
 │   ├── sample1_fastqc.zip
 │   ├── sample2_fastqc.html
 │   └── sample2_fastqc.zip
 ├── multiqc_outputs
-│   ├── fastqc_crispr_screen_data
+│   ├── multiqc_crispr_screen_data
 │   │   ├── fastqc_adapter_content_plot.txt
 │   │   ├── fastqc_overrepresented_sequences_plot.txt
 │   │   ├── fastqc_per_base_n_content_plot.txt
@@ -235,7 +252,7 @@ crispr_screen_out/
 │   │   ├── multiqc.log
 │   │   ├── multiqc_software_versions.txt
 │   │   └── multiqc_sources.txt
-│   └── fastqc_crispr_screen.html
+│   └── multiqc_crispr_screen.html
 ├── plots
 │   ├── geneCount_correlationMatrix.pdf
 │   ├── geneCount_PCA_plot.pdf
@@ -253,7 +270,7 @@ crispr_screen_out/
     └── transform_count_results.tsv
 ```
 
-To view the functional CRISPR screen analysis overview report, click on `dev_report.html`. All plots and stats are included in the respective `plots` and `qc_files` directories. Any intermediate files made by R are in the `count_output` directory along with the final sgRNA counts table per sample. The raw data at every step of the pipeline is provided for the user under the associated sub-directories with log files for how any given analysis went.
+To view the functional CRISPR screen analysis overview report, click on `report.html`. All plots and stats are included in the respective `plots` and `qc_files` directories. Any intermediate files made by R are in the `count_output` directory along with the final sgRNA counts table per sample. The raw data at every step of the pipeline is provided for the user under the associated sub-directories with log files for how any given analysis went.
 
 ## Contact Information
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Execute 5 jobs...
 
 Pipeline inputs and definitions are as follows:
 
-1\. **--cores:** The number of cores you want dedicated to the analysis, set to 10 as a default but should be changed based on the resources of where you're running the pipeline (i.e. local computer or HPC)
+1\. **--cores:** The number of cores you want dedicated to the analysis, set to 1 as a default but should be changed based on the resources of where you're running the pipeline (i.e. local computer or HPC)
 
 2\. **--raw_seq_dir:** The path to the directory containing the raw sequence `.fastq.gz` files
 
@@ -180,7 +180,7 @@ Pipeline inputs and definitions are as follows:
 
 | Parameter                 | Expected Type          | Input Required, Default, or Optional | Description                                                                                                      |
 |------------------|------------------|------------------|------------------|
-| --cores                   | numeric                | default = 1                         | The number of cores you want dedicated to the analysis, default of 10                                            |
+| --cores                   | numeric                | default = 1                         | The number of cores you want dedicated to the analysis, default of 1                                            |
 | --raw_seq_dir             | string of file path    | required                             | The path to the directory containing the raw sequence `.fastq.gz` files                                          |
 | --metadata_file           | string of file path    | required                             | The path to the metadata file as a `.csv`                                                                        |
 | --out_dir_name           | string    | default = "crispr_screen_out"                             | Provides option to change the name of the output directory                                                                        |

--- a/run_workflow.sh
+++ b/run_workflow.sh
@@ -11,14 +11,16 @@
 ## echo 'export PATH=/Users/apgarm/projects/immuno_micro_bioinformatics/functional_CRISPR_screen/:$PATH' >> ~/.zshrc
 
 functional_CRISPR_screen.py \
-    -c 10 \
+    -c 1 \
     --raw_seq_dir 'directory_with_raw_seqs' \
     --metadata_file 'path/to/metadata.csv' \
+    --out_dir_name 'my_project_name' \
     --bowtie_mismatches 0 \
     --vector_seq_used 'TTGTGGAAAGGACGAAACACCG' \
     --vector_seq_minOverlap 10 \
     --vector_seq_error 0.2 \
     --crispr_sgRNA_index "path/to/sgRNA_index.fasta" \
-    --crispr_sgRNA_index_name "name_of_sgRNA_index"
-    ## --use_singularity True \ ## only include this line if you want to run the pipeline in singularity/docker containers
-    ## --dry_run True  ## only include this line if you want to dry run the pipeline
+    --crispr_sgRNA_index_name "name_of_sgRNA_index" \
+    --latency_wait 60
+    ## --use_singularity \ ## only include this line if you want to run the pipeline in singularity/docker containers
+    ## --dry_run  ## only include this line if you want to dry run the pipeline

--- a/run_workflow_alpine.sh
+++ b/run_workflow_alpine.sh
@@ -38,11 +38,13 @@ functional_CRISPR_screen.py \
     -c 10 \
     --raw_seq_dir /scratch/alpine/${USER}/data_dir/20250814_LH00407_0160_A235GMTLT3/ \
     --metadata_file /scratch/alpine/${USER}/data_dir/metadata_for_pipeline.csv \
+    --out_dir_name 'crispr_screen_0822202' \
     --bowtie_mismatches 0 \
     --vector_seq_used TTGTGGAAAGGACGAAACACCG \
     --vector_seq_minOverlap 10 \
     --vector_seq_error 0.2 \
     --crispr_sgRNA_index /scratch/alpine/${USER}/data_dir/human_crispr_knockout_pooled_library_brunello.fasta \
     --crispr_sgRNA_index_name brunello \
-    --use_singularity True  ## only include this line if you want to run the pipeline in singularity/docker containers
-    ## --dry_run True  ## only include this line if you want to dry run the pipeline
+    --latency_wait 60 \
+    --use_singularity  ## only include this line if you want to run the pipeline in singularity/docker containers
+    ## --dry_run   ## only include this line if you want to dry run the pipeline

--- a/workflow/config/config.yml
+++ b/workflow/config/config.yml
@@ -1,5 +1,6 @@
 raw_seq_in: raw_crispr_data
 metadata_file: metadata.csv
+out_dir: my_project_name
 bowtie_mismatches: '0'
 vector_seq_used: TTGTGGAAAGGACGAAACACCG
 vector_seq_minOverlap: '10'

--- a/workflow/report/dev_report.qmd
+++ b/workflow/report/dev_report.qmd
@@ -3,9 +3,6 @@ title: "crispr functional screen analysis summary report"
 date: last-modified
 format:
     html: default
-    ##pdf: default
-editor: 
-    render-on-save: true
 ---
 
 # so you've run a CRISPR functional screen but what does it mean?
@@ -42,7 +39,7 @@ kable(summary_table, align='lcccccccc')
 ```
 
 | Column                           | Explanation                                                                                                                                                              |
-|-------------------------|-----------------------------------------------|
+|--------------------------|----------------------------------------------|
 | Total Reads Sequenced            | Total number of reads sequenced in your sample.                                                                                                                          |
 | Reads with Vector                | Total number of reads containing the vector sequence. This is the number of reads used for alignment.                                                                    |
 | Reads without Vector             | Total number of reads where the vector sequence was not detected and therefore not considered for sgRNA mapping. These reads are not included in the alignment step.     |
@@ -58,12 +55,10 @@ kable(summary_table, align='lcccccccc')
 
 below is a more in-depth description of how we process your raw sequences including the software used, outputs, and why we do each particular step.
 
-note: for the workflow .png to render in a non-blurry format you'll need to save it to the exact px dimensions that you want it to be in for the html (so this file). right now it's; w: 2850 px, h: 2311 px, dpi: 688.27.
-
 ![](plots/workflow_flowchart.png){width="2850"}
 
 | Workflow Step                            | Why we do this                                                                                                                                                                              |
-|------------------------|------------------------------------------------|
+|--------------------------|----------------------------------------------|
 | 1: Quality Check                         | Done to assess the overall quality of the sequences we received prior to additional analysis.                                                                                               |
 | 2: Raw Sequence Prep (trimming)          | To trim all found sequences from the 5' end to 20 base pairs (bp) in length based on the vector sequence of the library that was used. All sgRNA sequences should be about 20 bp in length. |
 | 3: Sequence Alignment                    | To map the trimmed sgRNA sequences to the associated library that they were prepped with to see which sgRNA sequences are present.                                                          |
@@ -92,17 +87,17 @@ total counts is exactly what it sounds like, adding up all the sgRNA/gene counts
 
 ### transformed counts
 
-the total sgRNA/gene counts above undergo a log2() transformation to ensure that the distribution of counts per sample is similar across all samples. like the plot above, the plot is colored by biological group and all replicates should be next to each other on the x-axis. **(why are we doing this??)**
+the total sgRNA/gene counts above undergo a log2() transformation to ensure that the distribution of counts per sample is similar across all samples. like the plot above, the plot is colored by biological group and all replicates should be next to each other on the x-axis.
 
 ![log2(Total Count Plot)](plots/sample_transCounts_plot.png)
 
 ## pca analysis
 
-we next put the counts-per-million (CPM) normalized sgRNA and gene counts through a principal components analysis (PCA) to look at the clustering of all replicates in a biological group. we expect replicates in the same biological group to cluster together (this is not a good example). we do this for sgRNA and gene counts separately since they're different and thus give us slightly different PCA results.
+we next put the counts-per-million (CPM) normalized sgRNA and gene counts through a principal components analysis (PCA) to look at the clustering of all replicates in a biological group, we expect replicates in the same biological group to cluster together. we do this for sgRNA and gene counts separately since they're different and thus give us slightly different PCA results.
 
 ### sgRNA count PCA
 
-we did this using all of the small guide RNA (sgRNA) sequences
+we did this using all of the small guide RNA (sgRNA) sequences.
 
 ![sgRNA Count PCA plot](plots/sgRNACount_PCA_plot.png)
 
@@ -118,21 +113,21 @@ we performed a spearman correlation analysis to make sure that all replicates in
 
 ### sgRNA correlation comparisons
 
-we did this for all small guide RNA (sgRNA) sequences - idk if we need this text
+we did this for all small guide RNA (sgRNA) sequences.
 
 ![sgRNA Count Correlation Plot](plots/sgRNACount_correlationMatrix.png)
 
 ### gene correlation comparisons
 
-this was done using the individual genes - same with this text
+this was done using the individual genes (similar to the gene count PCA above, all sgRNAs under one gene are added up).
 
 ![Gene Count Correlation Plot](plots/geneCount_correlationMatrix.png)
 
 # contact information
 
-If you have any questions regarding your results, our analysis, or ways to further process your data please feel free to contact us! As always, if we have done any analysis for you that ends up in a publication please consider including us in the author list.
+if you have any questions regarding your results, our analysis, or ways to further process your data please feel free to contact us! as always, if we have done any analysis for you that ends up in a publication please consider including us in the author list.
 
 **Madi Apgar, MS: madison.apgar\@cuanschutz.edu**\
 **Tonya Brunetti, PhD: tonya.brunetti\@cuanschutz.edu**
 
-This workflow is publically available as a [GitHub repository](https://github.com/Comp-Bio-Pipeline-Dev-Team/functional_CRISPR_screen).
+this workflow is publicly available as a [GitHub repository](https://github.com/Comp-Bio-Pipeline-Dev-Team/functional_CRISPR_screen).

--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -1,10 +1,18 @@
 import pandas as pd
-import os
+from os.path import join as pj
 
 ## ----USER PROVIDED INPUTS----
 ## via the config paramter in run_snakemake.sh
 metadata_csv = pd.read_csv(config["metadata_file"])
 SAMPLE_PREFIX = metadata_csv["sampleid"]
+
+## allows for output directory name to be specified by user
+## otherwise defaults to "crispr_screen_out"
+## need to test this!!
+if config["out_dir"] is not "crispr_screen_out":
+    OUT_DIR_NAME = "{}.{}".format(config["out_dir"], "crispr_screen_out")
+else:
+    OUT_DIR_NAME = config["out_dir"]
 
 RAW_SEQ_IN = config["raw_seq_in"]
 BOWTIE_MISMATCHES = config["bowtie_mismatches"]
@@ -13,8 +21,8 @@ BOWTIE_INDEX_FASTA = config["crispr_sgRNA_index"]
 BOWTIE_INDEX_NAME = config["crispr_sgRNA_index_name"]
 
 ## building the full file path of the bowtie index based on the name given by user
-BOWTIE_INDEX_DIR = os.path.join("reference_data", BOWTIE_INDEX_NAME)
-BOWTIE_INDEX = os.path.join(BOWTIE_INDEX_DIR, BOWTIE_INDEX_NAME)
+BOWTIE_INDEX_DIR = pj("reference_data", BOWTIE_INDEX_NAME)
+BOWTIE_INDEX = pj(BOWTIE_INDEX_DIR, BOWTIE_INDEX_NAME)
 
 
 ## ----CUTADAPT VECTOR VARIABLES----
@@ -47,52 +55,52 @@ UBUNTU_SING = "docker://tbrunetti/functional_crispr_screen:ubuntu-v24.04"
 ## only need to use `expand` in rule all 
 rule all:
     input:
-        "crispr_screen_out/fastqc_outputs/",
-        "crispr_screen_out/multiqc_outputs/fastqc_crispr_screen.html",
-        expand("crispr_screen_out/cutadapt_outputs/{sample_prefix}_trimmed.fastq.gz", 
+        pj(OUT_DIR_NAME,"fastqc_outputs/"),
+        pj(OUT_DIR_NAME, "multiqc_outputs/multiqc_crispr_screen.html"),
+        expand(pj(OUT_DIR_NAME, "cutadapt_outputs/{sample_prefix}_trimmed.fastq.gz"), 
                 sample_prefix = SAMPLE_PREFIX),
-        expand("crispr_screen_out/cutadapt_outputs/{sample_prefix}_untrimmed.fastq.gz",
+        expand(pj(OUT_DIR_NAME, "cutadapt_outputs/{sample_prefix}_untrimmed.fastq.gz"),
                 sample_prefix = SAMPLE_PREFIX),
         BOWTIE_INDEX_DIR,
-        expand("crispr_screen_out/bowtie_unaligned/{sample_prefix}_mismatches_allowed_unaligned.sam",
+        expand(pj(OUT_DIR_NAME, "bowtie_unaligned/{sample_prefix}_mismatches_allowed_unaligned.sam"),
                sample_prefix=SAMPLE_PREFIX),
-        expand("crispr_screen_out/bowtie_aligned/{sample_prefix}_mismatches_allowed.sam",
+        expand(pj(OUT_DIR_NAME, "bowtie_aligned/{sample_prefix}_mismatches_allowed.sam"),
                sample_prefix=SAMPLE_PREFIX),
-        expand("crispr_screen_out/bowtie_aligned/{sample_prefix}_mismatches_allowed.log",
+        expand(pj(OUT_DIR_NAME, "bowtie_aligned/{sample_prefix}_mismatches_allowed.log"),
                 sample_prefix=SAMPLE_PREFIX),
-        expand("crispr_screen_out/count_output/{sample_prefix}_counts.txt",
+        expand(pj(OUT_DIR_NAME, "count_output/{sample_prefix}_counts.txt"),
                 sample_prefix=SAMPLE_PREFIX),
-        expand("crispr_screen_out/count_output/{sample_prefix}_bbpileup.log",
+        expand(pj(OUT_DIR_NAME, "count_output/{sample_prefix}_bbpileup.log"),
                 sample_prefix=SAMPLE_PREFIX),
-        "crispr_screen_out/count_output/allSample_counts.tsv",
-        "crispr_screen_out/count_output/allSample_counts_long.tsv",
-        "crispr_screen_out/count_output/allSample_sgRNAcounts_wide.tsv",
-        "crispr_screen_out/count_output/norm-cpm_allSample_sgRNAcounts.tsv",
-        "crispr_screen_out/count_output/allSample_geneCounts_wide.tsv",
-        "crispr_screen_out/count_output/norm-cpm_allSample_geneCounts.tsv",
-        "crispr_screen_out/plots/sgRNACount_PCA_plot.pdf",
+        pj(OUT_DIR_NAME, "count_output/allSample_counts.tsv"),
+        pj(OUT_DIR_NAME, "count_output/allSample_counts_long.tsv"),
+        pj(OUT_DIR_NAME, "count_output/allSample_sgRNAcounts_wide.tsv"),
+        pj(OUT_DIR_NAME, "count_output/norm-cpm_allSample_sgRNAcounts.tsv"),
+        pj(OUT_DIR_NAME, "count_output/allSample_geneCounts_wide.tsv"),
+        pj(OUT_DIR_NAME, "count_output/norm-cpm_allSample_geneCounts.tsv"),
+        pj(OUT_DIR_NAME, "plots/sgRNACount_PCA_plot.pdf"),
         "workflow/report/plots/sgRNACount_PCA_plot.png",
-        "crispr_screen_out/plots/geneCount_PCA_plot.pdf",
+        pj(OUT_DIR_NAME, "plots/geneCount_PCA_plot.pdf"),
         "workflow/report/plots/geneCount_PCA_plot.png",
-        "crispr_screen_out/qc_files/sgRNACount_PCA_results.tsv",
-        "crispr_screen_out/qc_files/geneCount_PCA_results.tsv",
-        "crispr_screen_out/plots/sample_totalCount_plot.pdf",
+        pj(OUT_DIR_NAME, "qc_files/sgRNACount_PCA_results.tsv"),
+        pj(OUT_DIR_NAME, "qc_files/geneCount_PCA_results.tsv"),
+        pj(OUT_DIR_NAME, "plots/sample_totalCount_plot.pdf"),
         "workflow/report/plots/sample_totalCount_plot.png",
-        "crispr_screen_out/plots/sample_transCounts_plot.pdf",
+        pj(OUT_DIR_NAME, "plots/sample_transCounts_plot.pdf"),
         "workflow/report/plots/sample_transCounts_plot.png",
-        "crispr_screen_out/qc_files/total_count_results.tsv",
-        "crispr_screen_out/qc_files/transform_count_results.tsv",
-        "crispr_screen_out/plots/sgRNACount_correlationMatrix.pdf",
+        pj(OUT_DIR_NAME, "qc_files/total_count_results.tsv"),
+        pj(OUT_DIR_NAME, "qc_files/transform_count_results.tsv"),
+        pj(OUT_DIR_NAME, "plots/sgRNACount_correlationMatrix.pdf"),
         "workflow/report/plots/sgRNACount_correlationMatrix.png",
-        "crispr_screen_out/plots/geneCount_correlationMatrix.pdf",
+        pj(OUT_DIR_NAME, "plots/geneCount_correlationMatrix.pdf"),
         "workflow/report/plots/geneCount_correlationMatrix.png",
-        "crispr_screen_out/qc_files/sgRNACount_correlation_results.tsv",
-        "crispr_screen_out/qc_files/geneCount_correlation_results.tsv",
+        pj(OUT_DIR_NAME, "qc_files/sgRNACount_correlation_results.tsv"),
+        pj(OUT_DIR_NAME, "qc_files/geneCount_correlation_results.tsv"),
         expand("workflow/report/summary_stats/{sample_prefix}_overall_stats.tsv",
                 sample_prefix=SAMPLE_PREFIX),
-        "crispr_screen_out/qc_files/sample_summary_stat_table.tsv",
+        pj(OUT_DIR_NAME, "qc_files/sample_summary_stat_table.tsv"),
         "workflow/report/summary_stats/sample_summary_stat_table.tsv",
-        "crispr_screen_out/dev_report.html"
+        pj(OUT_DIR_NAME, "report.html")
         
 
 
@@ -105,7 +113,7 @@ rule run_fastqc:
     input:
         inDir = RAW_SEQ_IN
     output:
-        outDir = directory("crispr_screen_out/fastqc_outputs/")
+        outDir = directory(pj(OUT_DIR_NAME, "fastqc_outputs/"))
     singularity:
         FASTQC_SING
     conda:
@@ -124,16 +132,16 @@ rule run_fastqc:
 
 rule run_multiqc:
     input:
-        inDir = "crispr_screen_out/fastqc_outputs/"
+        inDir = pj(OUT_DIR_NAME, "fastqc_outputs/")
     output:
-        fastq_report_out = "crispr_screen_out/multiqc_outputs/fastqc_crispr_screen.html"
+        fastq_report_out = pj(OUT_DIR_NAME, "multiqc_outputs/multiqc_crispr_screen.html")
     singularity:
         MULTIQC_SING
     conda:
         MULTIQC_ENV
     params:
-        multiqc_dir = "crispr_screen_out/multiqc_outputs/",
-        multiqc_filename = "fastqc_crispr_screen.html"
+        multiqc_dir = pj(OUT_DIR_NAME, "multiqc_outputs/"),
+        multiqc_filename = "multiqc_crispr_screen.html"
     shell:
         """
         echo "running multiqc"
@@ -148,10 +156,10 @@ rule run_multiqc:
 ## around it 
 rule run_cutadapt:
     input:
-        in_samples = os.path.join(RAW_SEQ_IN, "{sample_prefix}.fastq.gz")
+        in_samples = pj(RAW_SEQ_IN, "{sample_prefix}.fastq.gz")
     output:
-        out_samples = "crispr_screen_out/cutadapt_outputs/{sample_prefix}_trimmed.fastq.gz",
-        out_untrimmed = "crispr_screen_out/cutadapt_outputs/{sample_prefix}_untrimmed.fastq.gz"
+        out_samples = pj(OUT_DIR_NAME, "cutadapt_outputs/{sample_prefix}_trimmed.fastq.gz"),
+        out_untrimmed = pj(OUT_DIR_NAME, "cutadapt_outputs/{sample_prefix}_untrimmed.fastq.gz")
     singularity:
         CUTADAPT_SING
     conda:
@@ -159,7 +167,7 @@ rule run_cutadapt:
     params:
         vector_seq = "\"{};min_overlap={};e={}\"".format(VECTOR_BP, VECTOR_MIN_OVERLP, VECTOR_ERROR),
         guide_length = 20,
-        tmp_out = "crispr_screen_out/cutadapt_outputs/tmp_{sample_prefix}.fastq.gz"
+        tmp_out = pj(OUT_DIR_NAME, "cutadapt_outputs/tmp_{sample_prefix}.fastq.gz")
     shell:
         """
         cutadapt -g {params.vector_seq} \
@@ -204,13 +212,13 @@ rule build_bowtie_index:
 
 rule run_bowtie:
     input:
-        in_samples = "crispr_screen_out/cutadapt_outputs/{sample_prefix}_trimmed.fastq.gz"
+        in_samples = pj(OUT_DIR_NAME, "cutadapt_outputs/{sample_prefix}_trimmed.fastq.gz")
     output:
-        unaligned_out = "crispr_screen_out/bowtie_unaligned/{sample_prefix}_mismatches_allowed_unaligned.sam",
-        aligned_out = "crispr_screen_out/bowtie_aligned/{sample_prefix}_mismatches_allowed.sam"
+        unaligned_out = pj(OUT_DIR_NAME, "bowtie_unaligned/{sample_prefix}_mismatches_allowed_unaligned.sam"),
+        aligned_out = pj(OUT_DIR_NAME, "bowtie_aligned/{sample_prefix}_mismatches_allowed.sam")
     ## can specify log outputs here
     log:
-        log = "crispr_screen_out/bowtie_aligned/{sample_prefix}_mismatches_allowed.log"
+        log = pj(OUT_DIR_NAME, "bowtie_aligned/{sample_prefix}_mismatches_allowed.log")
     singularity:
         BOWTIE_SING
     conda:
@@ -240,11 +248,11 @@ rule run_bowtie:
 ## the log file is typically empty with everything in the err file - should we just have a log file?
 rule run_bbmap:
     input:
-        in_samples = "crispr_screen_out/bowtie_aligned/{sample_prefix}_mismatches_allowed.sam"
+        in_samples = pj(OUT_DIR_NAME, "bowtie_aligned/{sample_prefix}_mismatches_allowed.sam")
     output:
-        count_out = "crispr_screen_out/count_output/{sample_prefix}_counts.txt"
+        count_out = pj(OUT_DIR_NAME, "count_output/{sample_prefix}_counts.txt")
     log:
-        log = "crispr_screen_out/count_output/{sample_prefix}_bbpileup.log"
+        log = pj(OUT_DIR_NAME, "count_output/{sample_prefix}_bbpileup.log")
     singularity:
         BBMAP_SING
     conda:
@@ -261,14 +269,14 @@ rule run_bbmap:
 ## any bash variables in curly brackets in the snakemake shell need to be escaped (double brackets instead of single)
 rule prep_count_files:
     input:
-        decoy_in = expand("crispr_screen_out/count_output/{sample_prefix}_counts.txt",
+        decoy_in = expand(pj(OUT_DIR_NAME, "count_output/{sample_prefix}_counts.txt"),
                            sample_prefix=SAMPLE_PREFIX)
     output:
-        combined_count_file = "crispr_screen_out/count_output/allSample_counts.tsv"
+        combined_count_file = pj(OUT_DIR_NAME, "count_output/allSample_counts.tsv")
     singularity:
         UBUNTU_SING
     params:
-        inDir = "crispr_screen_out/count_output/",
+        inDir = pj(OUT_DIR_NAME, "count_output/"),
         out_file_name = "allSample_counts.tsv"
     shell:
         """
@@ -287,14 +295,14 @@ rule prep_count_files:
 ## THE START OF R ANALYSIS
 rule normalize_counts:
     input:
-        comb_count_table = "crispr_screen_out/count_output/allSample_counts.tsv",
+        comb_count_table = pj(OUT_DIR_NAME, "count_output/allSample_counts.tsv"),
         metadata_file = METADATA
     output:
-        comb_countLong_out = "crispr_screen_out/count_output/allSample_counts_long.tsv",
-        sgRNA_counts_wide = "crispr_screen_out/count_output/allSample_sgRNAcounts_wide.tsv",
-        norm_sgRNA_counts = "crispr_screen_out/count_output/norm-cpm_allSample_sgRNAcounts.tsv",
-        gene_counts_wide = "crispr_screen_out/count_output/allSample_geneCounts_wide.tsv",
-        norm_gene_counts = "crispr_screen_out/count_output/norm-cpm_allSample_geneCounts.tsv"
+        comb_countLong_out = pj(OUT_DIR_NAME, "count_output/allSample_counts_long.tsv"),
+        sgRNA_counts_wide = pj(OUT_DIR_NAME, "count_output/allSample_sgRNAcounts_wide.tsv"),
+        norm_sgRNA_counts = pj(OUT_DIR_NAME, "count_output/norm-cpm_allSample_sgRNAcounts.tsv"),
+        gene_counts_wide = pj(OUT_DIR_NAME, "count_output/allSample_geneCounts_wide.tsv"),
+        norm_gene_counts = pj(OUT_DIR_NAME, "count_output/norm-cpm_allSample_geneCounts.tsv")
     singularity:
         R_SING
     conda:
@@ -315,15 +323,15 @@ rule normalize_counts:
 rule run_pca:
     input:
         metadata_file = METADATA,
-        norm_sgRNA_counts = "crispr_screen_out/count_output/norm-cpm_allSample_sgRNAcounts.tsv",
-        norm_gene_counts = "crispr_screen_out/count_output/norm-cpm_allSample_geneCounts.tsv"
+        norm_sgRNA_counts = pj(OUT_DIR_NAME, "count_output/norm-cpm_allSample_sgRNAcounts.tsv"),
+        norm_gene_counts = pj(OUT_DIR_NAME, "count_output/norm-cpm_allSample_geneCounts.tsv")
     output:
-        sgRNA_PCA_pdf = "crispr_screen_out/plots/sgRNACount_PCA_plot.pdf",
+        sgRNA_PCA_pdf = pj(OUT_DIR_NAME, "plots/sgRNACount_PCA_plot.pdf"),
         sgRNA_PCA_png = "workflow/report/plots/sgRNACount_PCA_plot.png",
-        gene_PCA_pdf = "crispr_screen_out/plots/geneCount_PCA_plot.pdf",
+        gene_PCA_pdf = pj(OUT_DIR_NAME, "plots/geneCount_PCA_plot.pdf"),
         gene_PCA_png = "workflow/report/plots/geneCount_PCA_plot.png", 
-        sgRNA_PCA_table = "crispr_screen_out/qc_files/sgRNACount_PCA_results.tsv",
-        gene_PCA_table = "crispr_screen_out/qc_files/geneCount_PCA_results.tsv"
+        sgRNA_PCA_table = pj(OUT_DIR_NAME, "qc_files/sgRNACount_PCA_results.tsv"),
+        gene_PCA_table = pj(OUT_DIR_NAME, "qc_files/geneCount_PCA_results.tsv")
     singularity:
         R_SING
     conda:
@@ -346,15 +354,15 @@ rule run_pca:
 
 rule run_total_transform_counts:
     input:
-        comb_countLong_table = "crispr_screen_out/count_output/allSample_counts_long.tsv",
+        comb_countLong_table = pj(OUT_DIR_NAME, "count_output/allSample_counts_long.tsv"),
         metadata_file = METADATA
     output:
-        total_count_pdf = "crispr_screen_out/plots/sample_totalCount_plot.pdf",
+        total_count_pdf = pj(OUT_DIR_NAME, "plots/sample_totalCount_plot.pdf"),
         total_count_png = "workflow/report/plots/sample_totalCount_plot.png",
-        trans_count_pdf = "crispr_screen_out/plots/sample_transCounts_plot.pdf",
+        trans_count_pdf = pj(OUT_DIR_NAME, "plots/sample_transCounts_plot.pdf"),
         trans_count_png = "workflow/report/plots/sample_transCounts_plot.png",
-        total_count_table = "crispr_screen_out/qc_files/total_count_results.tsv",
-        trans_count_table = "crispr_screen_out/qc_files/transform_count_results.tsv"
+        total_count_table = pj(OUT_DIR_NAME, "qc_files/total_count_results.tsv"),
+        trans_count_table = pj(OUT_DIR_NAME, "qc_files/transform_count_results.tsv")
     singularity:
         R_SING
     conda:
@@ -376,15 +384,15 @@ rule run_total_transform_counts:
 
 rule run_correlation:
     input:
-        sgRNA_counts_wide = "crispr_screen_out/count_output/allSample_sgRNAcounts_wide.tsv",
-        gene_counts_wide = "crispr_screen_out/count_output/allSample_geneCounts_wide.tsv" 
+        sgRNA_counts_wide = pj(OUT_DIR_NAME, "count_output/allSample_sgRNAcounts_wide.tsv"),
+        gene_counts_wide = pj(OUT_DIR_NAME, "count_output/allSample_geneCounts_wide.tsv") 
     output:
-        sgRNA_corr_pdf = "crispr_screen_out/plots/sgRNACount_correlationMatrix.pdf",
+        sgRNA_corr_pdf = pj(OUT_DIR_NAME, "plots/sgRNACount_correlationMatrix.pdf"),
         sgRNA_corr_png = "workflow/report/plots/sgRNACount_correlationMatrix.png",
-        gene_corr_pdf = "crispr_screen_out/plots/geneCount_correlationMatrix.pdf",
+        gene_corr_pdf = pj(OUT_DIR_NAME, "plots/geneCount_correlationMatrix.pdf"),
         gene_corr_png = "workflow/report/plots/geneCount_correlationMatrix.png",
-        sgRNA_corr_table = "crispr_screen_out/qc_files/sgRNACount_correlation_results.tsv",
-        gene_corr_table = "crispr_screen_out/qc_files/geneCount_correlation_results.tsv"
+        sgRNA_corr_table = pj(OUT_DIR_NAME, "qc_files/sgRNACount_correlation_results.tsv"),
+        gene_corr_table = pj(OUT_DIR_NAME, "qc_files/geneCount_correlation_results.tsv")
     singularity:
         R_SING
     conda:
@@ -407,12 +415,12 @@ rule run_correlation:
 ## THINGS NEEDED FOR REPORT GENERATION
 rule assemble_stat_table:
     input:
-        raw_file = os.path.join(RAW_SEQ_IN, "{sample_prefix}.fastq.gz"),
+        raw_file = pj(RAW_SEQ_IN, "{sample_prefix}.fastq.gz"),
         index_fasta_file = BOWTIE_INDEX_FASTA,
-        trimmed_file = "crispr_screen_out/cutadapt_outputs/{sample_prefix}_trimmed.fastq.gz",
-        untrimmed_file = "crispr_screen_out/cutadapt_outputs/{sample_prefix}_untrimmed.fastq.gz",
-        bowtie_log = "crispr_screen_out/bowtie_aligned/{sample_prefix}_mismatches_allowed.log",
-        counts_file = "crispr_screen_out/count_output/{sample_prefix}_counts.txt"
+        trimmed_file = pj(OUT_DIR_NAME, "cutadapt_outputs/{sample_prefix}_trimmed.fastq.gz"),
+        untrimmed_file = pj(OUT_DIR_NAME, "cutadapt_outputs/{sample_prefix}_untrimmed.fastq.gz"),
+        bowtie_log = pj(OUT_DIR_NAME, "bowtie_aligned/{sample_prefix}_mismatches_allowed.log"),
+        counts_file = pj(OUT_DIR_NAME, "count_output/{sample_prefix}_counts.txt")
     output:
         sample_stat_out = "workflow/report/summary_stats/{sample_prefix}_overall_stats.tsv"
     singularity:
@@ -461,7 +469,7 @@ rule combine_stat_table:
         samples_in = expand("workflow/report/summary_stats/{sample_prefix}_overall_stats.tsv",
                             sample_prefix=SAMPLE_PREFIX)
     output:
-        combined_stat_out = "crispr_screen_out/qc_files/sample_summary_stat_table.tsv",
+        combined_stat_out = pj(OUT_DIR_NAME, "qc_files/sample_summary_stat_table.tsv"),
         report_stat_out = "workflow/report/summary_stats/sample_summary_stat_table.tsv"
     singularity:
         UBUNTU_SING
@@ -485,7 +493,7 @@ rule render_report:
         combined_stat_table = "workflow/report/summary_stats/sample_summary_stat_table.tsv",
         report_doc = "workflow/report/dev_report.qmd"
     output:
-        report_copy = "crispr_screen_out/dev_report.html"
+        report_copy = pj(OUT_DIR_NAME, "report.html")
     singularity:
         QUARTO_SING
     conda:
@@ -494,13 +502,12 @@ rule render_report:
         bowtie_mismatches = BOWTIE_MISMATCHES,
         report_vars = "workflow/report/_variables.yml",
         report_html = "workflow/report/dev_report.html",
-        report_location = "crispr_screen_out/"
+        report_location = pj(OUT_DIR_NAME, "report.html") ## may not need this anymore since its exactly the same as output
     shell:
         """
         printf "bowtie_mismatches: {params.bowtie_mismatches}" > {params.report_vars}
 
         quarto render {input.report_doc}
 
-        ## may need to do something to how crispr_screen_out is referenced
-        cp {params.report_html} {params.report_location} 
+        cp {params.report_html} {params.report_copy} 
         """ 


### PR DESCRIPTION
**[Bug fixes]**
 - #10 : added `--latency_wait` parameter to wrapper script with a default of 60 seconds but can be changed by the user
 - #14 : fixed multiqc container to reference v1.26 and not v1.16. also added `--force` parameter to multiqc so that snakemake doesn't freak out about the multiqc outputs already existing 
 
**[Enhancements]**
- #9 : set `--use_singularity` and `--dry_run` parameters to True 
- added `--out_dir_name` parameter to wrapper script so users have the option of adding their project name as a prefix to the output directory (default is still `crispr_screen_out`)
- formalized language in `dev_report.qmd`
- changed the name of the multiqc output files from `fastqc_crispr_screen` to `multiqc_crispr_screen`
- changed the name of the report from `dev_report.html` to `report.html`
- added table of contents to `README.md`
- updated documentation in `README.md` to reflect changes in this PR 
- updated `run_workflow.sh` and `run_workflow_alpine.sh` scripts to reflect the additional wrapper script parameters 